### PR TITLE
Formatting edits to template

### DIFF
--- a/saml-idp-connector/idp-connector-configGuide-template.rst
+++ b/saml-idp-connector/idp-connector-configGuide-template.rst
@@ -11,9 +11,9 @@ This document describes the configuration for an external IDP Connector using an
 #. Select the :guilabel:`SAML Service Provider` to configure BIG-IP as a SAML Service Provider.
 #. Review the Required Configuration information and complete the following required steps before you configure the External IDP Connector.
 
-    - Provide the :guilabel:`Service Provider` details.
-    - Provide the :guilabel:`Virtual Server` configuration details.
-    - After you configure the External IDP connector, configure the Pool Settings and (optional) Endpoint Check and SSO settings.
+   - Provide the :guilabel:`Service Provider` details.
+   - Provide the :guilabel:`Virtual Server` configuration details.
+   - After you configure the External IDP connector, configure the Pool Settings and (optional) Endpoint Check and SSO settings.
 
 External IDP Connector Configuration in Guided Configuration
 ------------------------------------------------------------
@@ -36,32 +36,32 @@ Advanced Connector Settings
 If the basic settings do not provide the information you need to configure, show Advanced Settings by clicking :guilabel:`Show Advanced Settings`.
 
 Endpoint Settings
-~~~~~~~~~~~~~~~~~
+`````````````````
 
-    Select :guilabel:`POST/Redirect`  as your Single Sign-on Service Binding.
+- Select :guilabel:`POST/Redirect`  as your Single Sign-on Service Binding.
 
 Assertion Settings
-~~~~~~~~~~~~~~~~~~
+``````````````````
 
-    Specify whether the Identity Location is :guilabel:`Subject` or :guilabel:`Attribute`.
+- Specify whether the Identity Location is :guilabel:`Subject` or :guilabel:`Attribute`.
 
 Security Settings
-~~~~~~~~~~~~~~~~~
+`````````````````
 
-    Select :guilabel:`Yes` to sign Authentication requests, and select the appropriate signing algorithm.
+- Select :guilabel:`Yes` to sign Authentication requests, and select the appropriate signing algorithm.
 
 Certificate Settings
-~~~~~~~~~~~~~~~~~~~~
+````````````````````
 
-    Select :guilabel:`Yes`  if you want to detach the signature when using the redirect binding.
+- Select :guilabel:`Yes`  if you want to detach the signature when using the redirect binding.
 
-Click :guilabel:`Save & Next`. Complete the subsequent steps.
+- Click :guilabel:`Save & Next`. Complete the subsequent steps.
 
 Deploy the Configuration
 ------------------------
 
 #. Deploy the configuration from the :guilabel:`Summary` screen.
-#. To retrieve the metadata for this configuration, navigate to :menuselection:`Access -> Federation -> SAML Service Provider -> Local SP Services`.
+#. To retrieve the metadata for this configuration, navigate to :menuselection:`Access --> Federation --> SAML Service Provider --> Local SP Services`.
 #. Select the SAML SP object created by your workflow, and click :guilabel:`Export Metadata`.
 #. Use the SAML metadata file to configure the Service Provider configuraton in the external Identity Provider Administration console.
 
@@ -72,5 +72,5 @@ Setup $TEMPLATE_LABEL$ as Identity Provider
 Test the configuration
 ----------------------
 
-#. To test the configuration, click on the link *Click to test configuration* on the Summary page.
+#. To test the configuration, click on the link :guilabel:`Click to test configuration` on the Summary page.
 #. Provide test user credentials, and verify that the access to the backend application succeeds.


### PR DESCRIPTION
@dashoraf5 

#### What issue())s does this address?
Fixes N/A

#### What changes did you make, and why?
I made some formatting edits to the template used to generate the IDP connector documentation.
- Fixed the indentation of bulleted list
- Corrected the h2 header from "~" to "`" for consistency across clouddocs documentation set
- De-indented user steps in the subsections (the indent would have caused them to display as blockquotes in the rendered HTML).

#### Where should the reviewer start?


#### Any background context?

