### PR TITLE
Test combining the deployment and invalidation into a single script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,5 @@ deploy:
     branch: 3.0
     repo: f5devcentral/f5-bigip-agc-config-guides
   script:
-  - ./scripts/deploy-docs.sh publish-product-docs-to-prod agc v3.0
-  - aws cloudfront create-invalidation --distribution-id $AWS_DIST_ID --paths /products/agc/v3.0
+  - ./scripts/deploy-docs.sh 
   

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -6,4 +6,9 @@
 # Don't set -x
 # we need to keep the secret AWS variables out of the logs
 
-exec docker run --rm -it -v $PWD:$PWD --workdir $PWD -e  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET=$AWS_S3_BUCKET f5devcentral/containthedocs "$@"
+exec docker run --rm -i -v $PWD:$PWD --workdir $PWD -e  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET=$AWS_S3_BUCKET f5devcentral/containthedocs /bin/bash -s <<EOF
+
+publish-product-docs-to-prod agc v3.0
+aws cloudfront create-invalidation --distribution-id $AWS_DIST_ID --paths /products/agc/v3.0
+
+EOF


### PR DESCRIPTION
[tag a reviewer]
@dashoraf5 

#### What issue(s) does this address?
Fixes #<issueid>
N/A


#### What changes did you make, and why?
Because the travis build returned a script error when I tried to add the CloudFront invalidation after the deploy script, I had to combine the two into a single script. 

The primary change is that I added a command which invalidates the CloudFront cache, so the next request for the page will make CloudFront retrieve it directly from s3. 


#### Where should the reviewer start?

#### Any background context?

